### PR TITLE
Implement support for saving/loading Groups in NeoMatlabIO.

### DIFF
--- a/neo/core/spiketrainlist.py
+++ b/neo/core/spiketrainlist.py
@@ -115,6 +115,11 @@ class SpikeTrainList(ObjectList):
         else:
             return SpikeTrainList(items=items)
 
+    def __setitem__(self, i, value):
+        if self._items is None:
+            self._spiketrains_from_array()
+        self._items[i] = value
+
     def __str__(self):
         """Return str(self)"""
         if self._items is None:

--- a/neo/test/iotest/test_neomatlabio.py
+++ b/neo/test/iotest/test_neomatlabio.py
@@ -8,7 +8,7 @@ import quantities as pq
 
 from neo.core.analogsignal import AnalogSignal
 from neo.core.irregularlysampledsignal import IrregularlySampledSignal
-from neo import Block, Segment, SpikeTrain, ImageSequence
+from neo import Block, Segment, SpikeTrain, ImageSequence, Group
 from neo.test.iotest.common_io_test import BaseTestIO
 from neo.io.neomatlabio import NeoMatlabIO
 
@@ -26,7 +26,7 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
     files_to_download = []
 
     def test_write_read_single_spike(self):
-        block1 = Block()
+        block1 = Block(name="test_neomatlabio")
         seg = Segment('segment1')
         spiketrain1 = SpikeTrain([1] * pq.s, t_stop=10 * pq.s, sampling_rate=1 * pq.Hz)
         spiketrain1.annotate(yep='yop')
@@ -43,6 +43,8 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
         seg.irregularlysampledsignals.append(irrsig1)
         seg.imagesequences.append(image_sequence)
 
+        group1 = Group([spiketrain1, sig1])
+        block1.groups.append(group1)
 
         # write block
         filename = self.get_local_path('matlabiotestfile.mat')
@@ -71,6 +73,10 @@ class TestNeoMatlabIO(BaseTestIO, unittest.TestCase):
         spiketrain2 = block2.segments[0].spiketrains[0]
         assert 'yep' in spiketrain2.annotations
         assert spiketrain2.annotations['yep'] == 'yop'
+
+        # test group retrieval
+        group2 = block2.groups[0]
+        assert_array_equal(group1.analogsignals[0], group2.analogsignals[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi Zach,

Thanks for starting to implement a fix for https://github.com/NeuralEnsemble/python-neo/issues/1358

This is an update to https://github.com/NeuralEnsemble/python-neo/issues/1360, which adds support for saving and retrieving the content of groups.

This is done by saving references to objects inside groups, on the assumption that those objects are already stored somewhere within segments. This assumption may not always be true (e.g. ChannelViews), so probably we should only save references for objects that would otherwise be duplicated, and otherwise save the object itself. I haven't implemented this last part yet, and I suspect that groups containing groups won't be properly saved either, so there's a bit more work needed.